### PR TITLE
Namespacing issue when working with both LibLinear and LibSVM at the same time.

### DIFF
--- a/lib/linear.rb
+++ b/lib/linear.rb
@@ -51,7 +51,7 @@ class LParameter
   attr_accessor :param
   
   def initialize(*args)
-    @param = Parameter.new
+    @param = Liblinear::Parameter.new
     @param.solver_type = L2R_LR
     @param.C = 1
     @param.eps = 0.01
@@ -143,7 +143,7 @@ class LProblem
   
   def initialize(y,x,bias)
 #    assert_equal(y.size, x.size)
-    @prob = prob = Problem.new 
+    @prob = prob = Liblinear::Parameter.new
     @size = size = y.size
     
     @y_array = y_array = new_int(size)


### PR DESCRIPTION
Hi @tomz, I had to make this minor change to prevent LibLinear to clash with LibSVM.
