### PR TITLE
Remove calls to deprecated STR2CSTR

### DIFF
--- a/ext/liblinear_wrap.cxx
+++ b/ext/liblinear_wrap.cxx
@@ -1703,7 +1703,7 @@ SWIG_AsCharPtrAndSize(VALUE obj, char** cptr, size_t* psize, int *alloc)
     
 
 
-    char *cstr = STR2CSTR(obj);
+    char *cstr = StringValuePtr(obj);
     
     size_t size = RSTRING_LEN(obj) + 1;
     if (cptr)  {

--- a/liblinear-1.8/ruby/liblinear_wrap.cxx
+++ b/liblinear-1.8/ruby/liblinear_wrap.cxx
@@ -1703,7 +1703,7 @@ SWIG_AsCharPtrAndSize(VALUE obj, char** cptr, size_t* psize, int *alloc)
     
 
 
-    char *cstr = STR2CSTR(obj);
+    char *cstr = StringValuePtr(obj);
     
     size_t size = RSTRING_LEN(obj) + 1;
     if (cptr)  {


### PR DESCRIPTION
Ruby 1.9.2 removed the STR2CSTR macro. This replaces the use of that macro with StringValuePtr. Otherwise I get the following error when trying to bundle install:

```
Using liblinear-ruby-swig (0.2.1.1) from https://github.com/tomz/liblinear-ruby-swig.git (at master) with native extensions 
Gem::Installer::ExtensionBuildError: ERROR: Failed to build gem native extension.

        /Users/mattgordon/.rvm/rubies/ruby-1.9.3-p194/bin/ruby extconf.rb 
creating Makefile

make
compiling liblinear_wrap.cxx
liblinear_wrap.cxx: In function ‘int SWIG_AsCharPtrAndSize(VALUE, char**, size_t*, int*)’:
liblinear_wrap.cxx:1706: error: ‘STR2CSTR’ was not declared in this scope
make: *** [liblinear_wrap.o] Error 1
```
