### PR TITLE
Build .bundle into lib/ (RubyGems 3.4 compatibility)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gemspec
+
+group :development do
+  gem "rake"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,22 +1,6 @@
-require 'rubygems'
-gem 'hoe', '>=1.8.3','<= 1.12.2'
-require 'hoe'
+task :default => ["sync_files","make_gem"]
 
-
-task :default => ["sync_files","make_gem"] 
-
-EXT = "ext/liblinear?.#{Hoe::DLEXT}"
-
-Hoe.new('liblinear-ruby-swig', '0.3.0') do |p|
-  p.author = 'Tom Zeng'
-  p.email = 'tom.z.zeng@gmail.com'
-  p.url = 'http://www.tomzconsulting.com'
-  p.summary = 'Ruby wrapper of LIBLINEAR using SWIG'
-  p.description = 'Ruby wrapper of LIBLINEAR using SWIG'
-  
-  p.spec_extras[:extensions] = "ext/extconf.rb"
-  p.clean_globs << EXT << "ext/*.o" << "ext/Makefile"
-end
+EXT = "ext/liblinear?.#{RbConfig::CONFIG["DLEXT"]}"
 
 task :make_gem => EXT
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 task :default => ["sync_files","make_gem"]
 
-EXT = "ext/liblinear?.#{RbConfig::CONFIG["DLEXT"]}"
+EXT = "lib/liblinear?.#{RbConfig::CONFIG["DLEXT"]}"
 
 task :make_gem => EXT
 
@@ -8,6 +8,13 @@ file EXT => ["ext/extconf.rb", "ext/liblinear_wrap.cxx", "ext/linear.cpp", "ext/
   Dir.chdir "ext" do
     ruby "extconf.rb"
     sh "make"
+    cp "liblinear.bundle","../lib/"
+  end
+end
+
+task :clean do
+  Dir.chdir "ext" do
+    sh "make clean"
   end
 end
 

--- a/lib/linear.rb
+++ b/lib/linear.rb
@@ -1,4 +1,4 @@
-require 'liblinear'
+require 'liblinear-ruby-swig/liblinear'
 include Liblinear
 
 def _int_array(seq)

--- a/liblinear-ruby-swig.gemspec
+++ b/liblinear-ruby-swig.gemspec
@@ -20,13 +20,5 @@ Gem::Specification.new do |s|
   if s.respond_to? :specification_version then
     current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
     s.specification_version = 2
-
-    if Gem::Version.new(Gem::RubyGemsVersion) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<hoe>, [">= 1.8.3"])
-    else
-      s.add_dependency(%q<hoe>, [">= 1.8.3"])
-    end
-  else
-    s.add_dependency(%q<hoe>, [">= 1.8.3"])
   end
 end

--- a/liblinear-ruby-swig.gemspec
+++ b/liblinear-ruby-swig.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.has_rdoc = false
   s.homepage = %q{http://www.tomzconsulting.com}
   s.rdoc_options = ["--main", "README.rdoc"]
-  s.require_paths = ["lib","ext"]
+  s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.1}
   s.summary = %q{Ruby wrapper of LIBLINEAR using SWIG}
 


### PR DESCRIPTION
RubyGems 3.4+ runs `make clean` during `gem install`, effectively removing `liblinear.bundle` which renders this gem unusable.
https://github.com/rubygems/rubygems/issues/3958
https://github.com/rubygems/rubygems/pull/6133

As the standard directory for .bundle files is `lib/` (at least for modern Ruby versions), this pull request's changes will copy ext/liblinear.bundle to `lib/`. In addition, dependency on [Hoe](https://github.com/seattlerb/hoe) has been removed.

I have confirmed that the example script in README still produces expected output on Ruby 1.9.3-p0 + RubyGems 1.8.23 + Bundler 1.17.3. While I'm not sure about older Rubies, I'd assume that supporting a Ruby version from 2011 would give pretty good coverage in 2023.